### PR TITLE
Remove _lastOutputValue field from GpioPin

### DIFF
--- a/System.Device.Gpio/Properties/AssemblyInfo.cs
+++ b/System.Device.Gpio/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.0.3")]
+[assembly: AssemblyNativeVersion("100.1.0.4")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 


### PR DESCRIPTION
## Description
- Remove _lastOutputValue field from GpioPin.
- Bump AssemblyNativeVersion to v100.1.0.4

## Motivation and Context
- No need to store this value. Everything that was using it can be accommodated at native code more efficiently.

## How Has This Been Tested?<!-- (if applicable) -->
- Blinky sample.
- Test data: STM32F429I_DISCO toggle was blinking @ 8.5kHz, now is @ 20kHz.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
